### PR TITLE
Fix typings for react-scroll and card variants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 // src/App.tsx
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';
 import AboutPage from './pages/AboutPage';
@@ -21,7 +21,7 @@ const ScrollToTop = () => {
 
 const App: React.FC = () => {
   return (
-    <Router>
+    <>
       <ScrollToTop />
       <Layout>
         <Routes>
@@ -34,8 +34,7 @@ const App: React.FC = () => {
           {/* <Route path="/blog/:slug" element={<BlogDetailPage />} /> */}
         </Routes>
       </Layout>
-    </Router>
+    </>
   );
 };
-
 export default App;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,9 +1,9 @@
 // src/components/Card.tsx
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, type Variants } from 'framer-motion';
 import styles from './Card.module.css';
 
-const cardVariants = {
+const cardVariants: Variants = {
   offscreen: { y: 20, opacity: 0 },
   onscreen: {
     y: 0,

--- a/src/types/projects-module.d.ts
+++ b/src/types/projects-module.d.ts
@@ -1,0 +1,17 @@
+declare module '../data/projects' {
+  export interface Project {
+    slug: string;
+    title: string;
+    description: string;
+    tech_stack: string[];
+    created_date: string;
+    featured?: boolean;
+    github_url?: string;
+    demo_url?: string | null;
+    image_name?: string;
+    detailed_description?: string;
+    challenges?: string;
+    results?: string;
+  }
+  export const projects: Project[];
+}

--- a/src/types/react-scroll.d.ts
+++ b/src/types/react-scroll.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-scroll';


### PR DESCRIPTION
## Summary
- type `cardVariants`
- add react-scroll module definition
- add declaration for `../data/projects`
- remove inner `<Router>` from `App.tsx`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ef18a1fac83229cec8f411680cbaa